### PR TITLE
fix: prevent out-of-bounds panic in TokenTransfer::get_token_transfers

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -276,6 +276,12 @@ impl TokenTransfer {
     /// Parses a token transfer log and returns a vector of TokenTransfer objects
     pub fn get_token_transfers(log: &Log) -> Vec<TokenTransfer> {
         let mut results = vec![];
+
+        // Safety check: ensure topics is not empty before accessing
+        if log.topics().is_empty() {
+            return results;
+        }
+
         // erc20/erc721 transfer
         if log.topics()[0] == ERC20_TRANSFER_EVENT_SIGNATURE {
             if log.topics().len() == 3 {


### PR DESCRIPTION
### What
Add a safety check to ensure `log.topics()` is not empty before accessing `log.topics()[0]`.

### Why
Prevents potential out-of-bounds panic when processing logs with no topics.

### How
- Added a guard clause: return early if `log.topics().is_empty()`.
- Keeps existing ERC20/ERC721 transfer logic unchanged.

### Test Plan
- Ran existing unit tests (no failures).
- Verified that logs with empty topics no longer cause a panic.
