### PR TITLE
feat: simplify abi convert and signature comparison

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use alloy::sol_types::SolEvent;
 use std::collections::HashMap;
 
 /// Override state for contract storage during simulation
@@ -41,10 +42,13 @@ impl CallTrace {
     }
 }
 
-use crate::MyWrapDatabaseAsync;
+use crate::{
+    utils::abis::{IERC1155, IERC20, IERC721},
+    MyWrapDatabaseAsync,
+};
 use alloy::{
     network::AnyNetwork,
-    primitives::{fixed_bytes, Address, Bytes, FixedBytes, Log, TxKind, U256},
+    primitives::{Address, Bytes, Log, TxKind, U256},
     providers::{
         fillers::{BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller},
         Identity, RootProvider,
@@ -56,13 +60,6 @@ pub use revm::{
     interpreter::{CallScheme, CreateScheme},
 };
 use serde::{Deserialize, Serialize};
-
-pub const ERC20_TRANSFER_EVENT_SIGNATURE: FixedBytes<32> =
-    fixed_bytes!("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
-pub const ERC1155_TRANSFER_BATCH_EVENT_SIGNATURE: FixedBytes<32> =
-    fixed_bytes!("0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb");
-pub const ERC1155_TRANSFER_SINGLE_EVENT_SIGNATURE: FixedBytes<32> =
-    fixed_bytes!("0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62");
 
 // ========================= Provider Type Definitions =========================
 //
@@ -107,7 +104,7 @@ pub type AnyNetworkProvider = FillProvider<AllFillers, RootProvider<AnyNetwork>,
 
 pub type ArcAnyNetworkProvider = std::sync::Arc<AnyNetworkProvider>;
 
-pub const NATIVE_TOKEN_ADDRESS: Address = Address::ZERO;
+pub const NATIVE_TOKEN_ADDRESS: Address = Address::ZERO; // TODO should we use 0xeee.eeee?
 
 pub type AllDBType = MyWrapDatabaseAsync<AlloyDB<AnyNetwork, AnyNetworkProvider>>;
 
@@ -282,13 +279,15 @@ impl TokenTransfer {
             return results;
         }
 
-        // erc20/erc721 transfer
-        if log.topics()[0] == ERC20_TRANSFER_EVENT_SIGNATURE {
-            if log.topics().len() == 3 {
-                let from = Address::from_slice(&log.topics()[1].as_slice()[12..]);
-                let to = Address::from_slice(&log.topics()[2].as_slice()[12..]);
-                let data = &log.data.data;
-                let amount = U256::from_be_slice(data);
+        let topic0 = log.topics()[0];
+        match topic0 {
+            s if s == IERC20::Transfer::SIGNATURE_HASH => {
+                // decode the transfer event
+                let decoded = IERC20::Transfer::decode_log(log).unwrap();
+                let from = decoded.from;
+                let to = decoded.to;
+                let amount = decoded.value;
+
                 if !amount.is_zero() {
                     results.push(TokenTransfer {
                         token: log.address,
@@ -299,73 +298,66 @@ impl TokenTransfer {
                         id: None,
                     });
                 }
-            } else if log.topics().len() == 4 {
-                let from = Address::from_slice(&log.topics()[1].as_slice()[12..]);
-                let to = Address::from_slice(&log.topics()[2].as_slice()[12..]);
-                let id = U256::from_be_slice(log.topics()[3].as_slice());
-                let amount = U256::from(1);
+            }
+            s if s == IERC721::Transfer::SIGNATURE_HASH => {
+                // decode the transfer event
+                let decoded = IERC721::Transfer::decode_log(log).unwrap();
+                let from = decoded.from;
+                let to = decoded.to;
+                let token_id = decoded.tokenId;
+
                 results.push(TokenTransfer {
                     token: log.address,
                     from,
                     to: Some(to),
-                    value: amount,
+                    value: U256::ONE,
                     token_type: TokenType::ERC721,
-                    id: Some(id),
+                    id: Some(token_id),
                 });
             }
-        } else if log.topics()[0] == ERC1155_TRANSFER_BATCH_EVENT_SIGNATURE
-            && log.topics().len() == 4
-        {
-            let data = &log.data.data;
-            if data.len() >= 96 {
-                let from = Address::from_slice(&log.topics()[2].as_slice()[12..]);
-                let to = Address::from_slice(&log.topics()[3].as_slice()[12..]);
-                let ids_len = U256::from_be_slice(&data[64..96]).to::<usize>();
-                let mut ids = Vec::with_capacity(ids_len);
-                let mut offset = 96;
-                for _ in 0..ids_len {
-                    ids.push(U256::from_be_slice(&data[offset..offset + 32]));
-                    offset += 32;
-                }
-                // 解析 values
-                let values_len = U256::from_be_slice(&data[offset..offset + 32]).to::<usize>();
-                offset += 32;
-                let mut values = Vec::with_capacity(values_len);
-                for _ in 0..values_len {
-                    values.push(U256::from_be_slice(&data[offset..offset + 32]));
-                    offset += 32;
-                }
-                // 匹配 ids 和 values
-                for (id, value) in ids.into_iter().zip(values.into_iter()) {
-                    results.push(TokenTransfer {
-                        token: log.address,
-                        from,
-                        to: Some(to),
-                        value,
-                        token_type: TokenType::ERC1155,
-                        id: Some(id),
-                    });
-                }
-            }
-        } else if log.topics()[0] == ERC1155_TRANSFER_SINGLE_EVENT_SIGNATURE
-            && log.topics().len() == 4
-        {
-            let data = &log.data.data;
-            if data.len() >= 64 {
-                let from = Address::from_slice(&log.topics()[2].as_slice()[12..]);
-                let to = Address::from_slice(&log.topics()[3].as_slice()[12..]);
-                let id = U256::from_be_slice(&data[..32]);
-                let value = U256::from_be_slice(&data[32..64]);
+            s if s == IERC1155::TransferSingle::SIGNATURE_HASH => {
+                // decode the transfer event
+                let decoded = IERC1155::TransferSingle::decode_log(log).unwrap();
+                let _ = decoded.operator;
+                let from = decoded.from;
+                let to = decoded.to;
+                let token_id = decoded.id;
+                let value = decoded.value;
+
                 results.push(TokenTransfer {
                     token: log.address,
                     from,
                     to: Some(to),
                     value,
                     token_type: TokenType::ERC1155,
-                    id: Some(id),
+                    id: Some(token_id),
                 });
             }
+            s if s == IERC1155::TransferBatch::SIGNATURE_HASH => {
+                // decode the transfer event
+                let decoded = IERC1155::TransferBatch::decode_log(log).unwrap();
+                let _ = decoded.operator;
+                let from = decoded.from;
+                let to = decoded.to;
+                let ids = decoded.ids.clone();
+                let values = decoded.values.clone();
+
+                for i in 0..ids.len() {
+                    results.push(TokenTransfer {
+                        token: log.address,
+                        from,
+                        to: Some(to),
+                        value: values[i],
+                        token_type: TokenType::ERC1155,
+                        id: Some(ids[i]),
+                    });
+                }
+            }
+            _ => {
+                unreachable!("Not supported event: {:?}", topic0);
+            }
         }
+
         results
     }
 }

--- a/src/utils/abis/ierc1155.rs
+++ b/src/utils/abis/ierc1155.rs
@@ -1,0 +1,19 @@
+use alloy::sol;
+
+// https://eips.ethereum.org/EIPS/eip-1155
+sol! {
+    #[sol(rpc)]
+    contract IERC1155 {
+        event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
+        event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values);
+        event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+        event URI(string value, uint256 indexed id);
+
+        function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes calldata data) external;
+        function safeBatchTransferFrom(address from, address to, uint256[] ids, uint256[] values, bytes calldata data) external;
+        function balanceOf(address owner, uint256 id) external view returns (uint256);
+        function balanceOfBatch(address[] calldata owners, uint256[] calldata ids) external view returns (uint256[] memory);
+        function setApprovalForAll(address operator, bool approved) external;
+        function isApprovedForAll(address owner, address operator) external view returns (bool);
+    }
+}

--- a/src/utils/abis/ierc20.rs
+++ b/src/utils/abis/ierc20.rs
@@ -1,0 +1,20 @@
+use alloy::sol;
+
+// https://eips.ethereum.org/EIPS/eip-20
+sol! {
+    #[sol(rpc)]
+    contract IERC20 {
+        event Transfer(address indexed from, address indexed to, uint256 value);
+        event Approval(address indexed owner, address indexed spender, uint256 value);
+
+        function name() public view returns (string);
+        function symbol() public view returns (string);
+        function decimals() public view returns (uint8);
+        function totalSupply() public view returns (uint256);
+        function balanceOf(address owner) public view returns (uint256 balance);
+        function transfer(address to, uint256 value) public returns (bool success);
+        function transferFrom(address from, address to, uint256 value) public returns (bool success);
+        function approve(address spender, uint256 value) public returns (bool success);
+        function allowance(address owner, address spender) public view returns (uint256 remaining);
+    }
+}

--- a/src/utils/abis/ierc721.rs
+++ b/src/utils/abis/ierc721.rs
@@ -1,0 +1,26 @@
+use alloy::sol;
+
+// https://eips.ethereum.org/EIPS/eip-721
+sol! {
+    #[sol(rpc)]
+    contract IERC721 {
+        event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+        event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+        event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+        function balanceOf(address owner) external view returns (uint256);
+        function ownerOf(uint256 tokenId) external view returns (address);
+        function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external payable;
+        function safeTransferFrom(address from, address to, uint256 tokenId) external payable;
+        function transferFrom(address from, address to, uint256 tokenId) external payable;
+        function approve(address approved, uint256 tokenId) external payable;
+        function setApprovalForAll(address operator, bool approved) external;
+        function getApproved(uint256 tokenId) external view returns (address);
+        function isApprovedForAll(address owner, address operator) external view returns (bool);
+
+        // metadata
+        function name() external view returns (string name);
+        function symbol() external view returns (string symbol);
+        function tokenURI(uint256 tokenId) external view returns (string);
+    }
+}

--- a/src/utils/abis/mod.rs
+++ b/src/utils/abis/mod.rs
@@ -1,0 +1,7 @@
+pub mod ierc1155;
+pub mod ierc20;
+pub mod ierc721;
+
+pub use ierc1155::IERC1155;
+pub use ierc20::IERC20;
+pub use ierc721::IERC721;

--- a/src/utils/erc20_utils.rs
+++ b/src/utils/erc20_utils.rs
@@ -6,12 +6,13 @@
 use crate::{
     errors::{EvmError, TokenError},
     evm::TraceEvm,
-    types::{TokenInfo, ERC20_TRANSFER_EVENT_SIGNATURE},
+    types::TokenInfo,
+    utils::abis::IERC20,
 };
 use alloy::{
     primitives::{Address, Bytes, FixedBytes, TxKind, U256},
     sol,
-    sol_types::SolCall,
+    sol_types::{SolCall, SolEvent},
 };
 use anyhow::Result;
 use revm::{
@@ -270,7 +271,7 @@ pub fn parse_transfer_log(
     topics: &[FixedBytes<32>],
     data: &[u8],
 ) -> Option<(Address, Address, U256)> {
-    if topics.len() < 3 || topics[0] != ERC20_TRANSFER_EVENT_SIGNATURE {
+    if topics.len() < 3 || topics[0] != IERC20::Transfer::SIGNATURE_HASH {
         return None;
     }
     let amount = U256::from_be_slice(data);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@
 //! - **Proxy contracts**: Implementation resolution and detection
 //! - **Multicall operations**: Batch contract call execution
 
+pub mod abis;
 pub mod balance_utils;
 pub mod erc20_utils;
 pub mod error_utils;


### PR DESCRIPTION
## Modifications
- Introduce "abis" module: ierc20, ierc721 and ierc1155;
- Use `sol!`macro to simplify the log decoding
- Use `match` in stead of `if-else` grammar